### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/src/modules/AIRouteRules/Rules/components/Rules.vue
+++ b/src/modules/AIRouteRules/Rules/components/Rules.vue
@@ -425,7 +425,7 @@ export default {
                 return;
             }
 
-            const urlPattern = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})(\/[^\s?#]*)*\/?$/i;
+            const urlPattern = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})(\/[^\s?#]*)?\/?$/i;
             if (!urlPattern.test(value)) {
                 callback(new Error(this.$t('com.tipFormatError')));
                 return;


### PR DESCRIPTION
Potential fix for [https://github.com/yf-networks/ai-gateway-web/security/code-scanning/4](https://github.com/yf-networks/ai-gateway-web/security/code-scanning/4)

In general, the way to fix this kind of inefficiency is to avoid nested greedy quantifiers over ambiguous sub-patterns. Instead of `(...*...)*` with a broad character class like `[^\s?#]*`, constrain what each repetition is allowed to consume and remove ambiguity so that there are no multiple equivalent ways to match the same substring.

For this specific regex:

```js
/^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})(\/[^\s?#]*)*\/?$/i
```

the problematic part is `(/[^\s?#]*)*\/?`. This allows an arbitrary number of “path segments”, each of which itself may include zero or more non-space, non-`?`, non-`#` characters. That creates nested repetition (`*` inside `*`) and unnecessary ambiguity, especially when there are consecutive `/` characters. A more efficient and semantically clear approach is to treat the entire path as a single optional component after the domain, using one quantified class rather than repeating segments: e.g. `(/[^\s?#]*)?` — one optional `/` followed by zero or more valid path characters until `?`, `#`, whitespace, or end. This preserves behavior: previously you could match `/`, `/foo`, `/foo/bar`, `//`, etc. and you still can with the single path component. It also removes the nested quantifier pattern that triggers exponential backtracking.

So, in `src/modules/AIRouteRules/Rules/components/Rules.vue`, in the `validateUrl` method, update the `urlPattern` definition on line 428 to:

```js
const urlPattern = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})(\/[^\s?#]*)?\/?$/i;
```

No additional imports or helper methods are needed; we are only changing the regex literal inside the existing method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
